### PR TITLE
Updated microservices-demo version.

### DIFF
--- a/deployment-ms-a.yaml
+++ b/deployment-ms-a.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.4
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.4
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.4
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -152,7 +152,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.4
         ports:
         - containerPort: 3550
         env:

--- a/deployment-ms-b.yaml
+++ b/deployment-ms-b.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.4
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.4
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -75,7 +75,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.4
         ports:
         - containerPort: 7070
         env:
@@ -111,7 +111,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.4
         ports:
         - name: grpc
           containerPort: 7000
@@ -180,7 +180,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
         ports:
         - containerPort: 9555
         env:

--- a/deployment-ms-c.yaml
+++ b/deployment-ms-c.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.4
         ports:
         - containerPort: 8080
         env:
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
         ports:
         - containerPort: 50051
         env:
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.4
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.4
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
The adservice microservice v0.2.4 is no longer available and it is affecting the builds of skupper specially when executing the hipstershop test (unable to pull 0.2.4 version) https://console.cloud.google.com/gcr/images/google-samples/global/microservices-demo/adservice