### PR TITLE
Downgrade all microservices image version but adservice image version

### DIFF
--- a/deployment-ms-a.yaml
+++ b/deployment-ms-a.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.0
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.4
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.0
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -152,7 +152,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.0
         ports:
         - containerPort: 3550
         env:

--- a/deployment-ms-b.yaml
+++ b/deployment-ms-b.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.4
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.0
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -75,7 +75,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.0
         ports:
         - containerPort: 7070
         env:
@@ -111,7 +111,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.0
         ports:
         - name: grpc
           containerPort: 7000

--- a/deployment-ms-c.yaml
+++ b/deployment-ms-c.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.0
         ports:
         - containerPort: 8080
         env:
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.0
         ports:
         - containerPort: 50051
         env:
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.0
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
Newer versions (>0.3.0) affect to the hipster-shop integration test, particularly paymentservice and checkoutservice. Adservice remains with 0.3.4 version due unavailability of older versions.
