### PR TITLE
Align envs with upstream

### DIFF
--- a/resources-a/deployment-ms-a.yaml
+++ b/resources-a/deployment-ms-a.yaml
@@ -43,11 +43,7 @@ spec:
           value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice:3550"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
-          value: "1"
-        - name: DISABLE_DEBUGGER
           value: "1"
 ---
 apiVersion: apps/v1
@@ -104,7 +100,7 @@ spec:
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
           - name: SHOPPING_ASSISTANT_SERVICE_ADDR
-            value: "shoppingassistant:80"
+            value: "shoppingassistantservice:80"
           # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
           # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
           # - name: ENV_PLATFORM 
@@ -162,10 +158,6 @@ spec:
         env:
         - name: PORT
           value: "3550"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
         readinessProbe:

--- a/resources-b/deployment-ms-b.yaml
+++ b/resources-b/deployment-ms-b.yaml
@@ -50,12 +50,6 @@ spec:
             value: "currencyservice:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice:7070"
-          - name: DISABLE_STATS
-            value: "1"
-          - name: DISABLE_TRACING
-            value: "1"
-          - name: DISABLE_PROFILER
-            value: "1"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -112,11 +106,7 @@ spec:
         env:
         - name: PORT
           value: "7000"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
-          value: "1"
-        - name: DISABLE_DEBUGGER
           value: "1"
         readinessProbe:
           grpc:
@@ -180,10 +170,6 @@ spec:
         env:
         - name: PORT
           value: "9555"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15

--- a/resources-c/deployment-ms-c.yaml
+++ b/resources-c/deployment-ms-c.yaml
@@ -32,8 +32,6 @@ spec:
         env:
         - name: PORT
           value: "8080"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
         readinessProbe:
@@ -97,10 +95,6 @@ spec:
         env:
         - name: PORT
           value: "50051"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
         readinessProbe:


### PR DESCRIPTION
Noticed some envs were remove/modified in the latest release of google microservice demo.