### PR TITLE
Modified listeners/connectors to only required cross-site services

### DIFF
--- a/resources-a/connectors.yaml
+++ b/resources-a/connectors.yaml
@@ -7,15 +7,3 @@ spec:
   routingKey: productcatalogservice
   selector: app=productcatalogservice
   type: tcp
-
----
-apiVersion: skupper.io/v2alpha1
-kind: Connector
-metadata:
-  name: recommendationservice
-spec:
-  port: 8080
-  routingKey: recommendationservice
-  selector: app=recommendationservice
-  type: tcp
-

--- a/resources-a/listeners.yaml
+++ b/resources-a/listeners.yaml
@@ -42,26 +42,6 @@ spec:
 apiVersion: skupper.io/v2alpha1
 kind: Listener
 metadata:
-  name: productcatalogservice
-spec:
-  host: productcatalogservice
-  port: 3550
-  routingKey: productcatalogservice
-  type: tcp
----
-apiVersion: skupper.io/v2alpha1
-kind: Listener
-metadata:
-  name: recommendationservice
-spec:
-  host: recommendationservice
-  port: 8080
-  routingKey: recommendationservice
-  type: tcp
----
-apiVersion: skupper.io/v2alpha1
-kind: Listener
-metadata:
   name: shippingservice
 spec:
   host: shippingservice

--- a/resources-b/connectors.yaml
+++ b/resources-b/connectors.yaml
@@ -40,15 +40,3 @@ spec:
   routingKey: adservice
   selector: app=adservice
   type: tcp
-
----
-apiVersion: skupper.io/v2alpha1
-kind: Connector
-metadata:
-  name: redis-cart
-spec:
-  port: 6379
-  routingKey: redis-cart
-  selector: app=redis-cart
-  type: tcp
-

--- a/resources-b/listeners.yaml
+++ b/resources-b/listeners.yaml
@@ -2,26 +2,6 @@
 apiVersion: skupper.io/v2alpha1
 kind: Listener
 metadata:
-  name: cartservice
-spec:
-  host: cartservice
-  port: 7070
-  routingKey: cartservice
-  type: tcp
----
-apiVersion: skupper.io/v2alpha1
-kind: Listener
-metadata:
-  name: currencyservice
-spec:
-  host: currencyservice
-  port: 7000
-  routingKey: currencyservice
-  type: tcp
----
-apiVersion: skupper.io/v2alpha1
-kind: Listener
-metadata:
   name: emailservice
 spec:
   host: emailservice
@@ -37,16 +17,6 @@ spec:
   host: paymentservice
   port: 50051
   routingKey: paymentservice
-  type: tcp
----
-apiVersion: skupper.io/v2alpha1
-kind: Listener
-metadata:
-  name: redis-cart
-spec:
-  host: redis-cart
-  port: 6379
-  routingKey: redis-cart
   type: tcp
 ---
 apiVersion: skupper.io/v2alpha1


### PR DESCRIPTION
Keep a Connector only where a service is produced and must be exported to other sites.
Keep a Listener only where a service is consumed from another site.
Frontend in A gets only what it needs from B/C; checkoutservice in B gets only what it needs from A/C.